### PR TITLE
fix: reentrancy vulnerability on badge minting

### DIFF
--- a/.gas-snapshot
+++ b/.gas-snapshot
@@ -1,2 +1,2 @@
-E2EButtPlugWars:testRoadmap_E2E() (gas: 784967488)
-E2EScoring:testScoring_E2E() (gas: 21964412)
+E2EButtPlugWars:testRoadmap_E2E() (gas: 784965808)
+E2EScoring:testScoring_E2E() (gas: 21963865)

--- a/solidity/contracts/ButtPlugWars.sol
+++ b/solidity/contracts/ButtPlugWars.sol
@@ -188,7 +188,7 @@ contract ButtPlugWars is GameSchema, AddressRegistry, ERC721 {
         _badgeId = _calcMedalBadge(_totalWeight, _totalScore, _salt);
 
         emit MedalMinted(_badgeId, _salt, _badgeIds, _totalScore);
-        _mint(msg.sender, _badgeId); // msg.sender supports ERC721, as it a badge
+        _mint(msg.sender, _badgeId); // msg.sender supports ERC721, as it had a badge
     }
 
     function _processBadge(uint256 _badgeId) internal returns (uint256 _weight, uint256 _score) {

--- a/solidity/contracts/ButtPlugWars.sol
+++ b/solidity/contracts/ButtPlugWars.sol
@@ -143,10 +143,10 @@ contract ButtPlugWars is GameSchema, AddressRegistry, ERC721 {
         if (matchesWon[_team] == 4) revert WrongTeam();
 
         _badgeId = _calcPlayerBadge(_tokenId, _team, _weight);
-        _safeMint(msg.sender, _badgeId);
 
         // msg.sender must approve the FiveOutOfNine transfer
         ERC721(FIVE_OUT_OF_NINE).safeTransferFrom(msg.sender, address(this), _tokenId);
+        _mint(msg.sender, _badgeId); // msg.sender supports ERC721, as it had a 5/9
     }
 
     /// @dev Allows the signer to register a ButtPlug NFT
@@ -188,7 +188,7 @@ contract ButtPlugWars is GameSchema, AddressRegistry, ERC721 {
         _badgeId = _calcMedalBadge(_totalWeight, _totalScore, _salt);
 
         emit MedalMinted(_badgeId, _salt, _badgeIds, _totalScore);
-        _safeMint(msg.sender, _badgeId);
+        _mint(msg.sender, _badgeId); // msg.sender supports ERC721, as it a badge
     }
 
     function _processBadge(uint256 _badgeId) internal returns (uint256 _weight, uint256 _score) {


### PR DESCRIPTION
```solidity
/**
* Reentrancy exploit
* A sender can mint +2 players with the same token when game about to finish 
*/

mintPlayer(1) // uses token 1 to mint badge A
  _safeMint(msg.sender, A)
  5/9.transferFrom(msg.sender, this, 1) // contract has token 1

mintPlayer(1)
  _safeMint(B) {      // reenters
    executeMove()     // checkmates => state.gameOver
    unbondLiquidity() // => state.preparations
    mintMedal(A)      // mints medal w/ badge A
      _processBadge(A)
        5/9.transferFrom(this, msg.sender, 1)  // msg.sender has now token 1
    _safeMint(msg.sender, MEDAL)
  }
  5/9.transferFrom(msg.sender, this, 1) // msg.sender minted B w/ same token

mintMedal(B) // minted 2 medals w/ same token
```
